### PR TITLE
change strings for kingdon's e2e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ ENV CGO_ENABLED=0
 ADD https://codecov.io/bash /usr/local/bin/codecov
 RUN chmod +x /usr/local/bin/codecov
 
-COPY glide.yaml /go/src/github.com/deis/workflow-cli/
-COPY glide.lock /go/src/github.com/deis/workflow-cli/
+COPY glide.yaml /go/src/github.com/teamhephy/workflow-cli/
+COPY glide.lock /go/src/github.com/teamhephy/workflow-cli/
 
-WORKDIR /go/src/github.com/deis/workflow-cli
+WORKDIR /go/src/github.com/teamhephy/workflow-cli
 
 RUN glide install --strip-vendor
 
 COPY ./_scripts /usr/local/bin
 
-COPY . /go/src/github.com/deis/workflow-cli
+COPY . /go/src/github.com/teamhephy/workflow-cli

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # the filepath to this repository, relative to $GOPATH/src
-repo_path = github.com/deis/workflow-cli
+repo_path = github.com/teamhephy/workflow-cli
 
 HOST_OS := $(shell uname)
 ifeq ($(HOST_OS),Darwin)
@@ -13,7 +13,7 @@ GIT_TAG ?= $(shell git describe --abbrev=0 --tags)
 REVISION ?= $(shell git rev-parse --short HEAD)
 
 REGISTRY ?= quay.io/
-IMAGE_PREFIX ?= deisci
+IMAGE_PREFIX ?= kingdonb
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/workflow-cli-dev:${REVISION}
 
 BUILD_OS ?=linux darwin windows
@@ -32,34 +32,34 @@ endef
 
 build: build-test-image
 	$(eval GO_LDFLAGS= -ldflags '-X ${repo_path}/version.Version=dev-${REVISION}')
-	docker run --rm -e GOOS=${GOOS} -v ${CURDIR}/_dist:/out ${IMAGE} go build -a -installsuffix cgo ${GO_LDFLAGS} -o /out/deis .
-	@$(call check-static-binary,_dist/deis)
-	@echo "${GOOS} binary written to _dist/deis"
+	docker run --rm -e GOOS=${GOOS} -v ${CURDIR}/_dist:/out ${IMAGE} go build -a -installsuffix cgo ${GO_LDFLAGS} -o /out/hephy .
+	@$(call check-static-binary,_dist/hephy)
+	@echo "${GOOS} binary written to _dist/hephy"
 
 # This is supposed to be run within a docker container
 build-latest:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}-${REVISION}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/deis-latest-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/hephy-latest-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
 build-revision:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}-${REVISION}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${REVISION}/deis-${REVISION}-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${REVISION}/hephy-${REVISION}-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
 build-stable:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/deis-stable-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/hephy-stable-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
 build-tag:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${GIT_TAG}/deis-${GIT_TAG}-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${GIT_TAG}/hephy-${GIT_TAG}-{{.OS}}-{{.Arch}}" .
 
 build-all: build-latest build-revision
 
 install:
-	cp deis $$GOPATH/bin
+	cp hephy $$GOPATH/bin
 
 test-style: build-test-image
 	docker run --rm ${IMAGE} lint

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/apps"
-	"github.com/deis/controller-sdk-go/config"
-	"github.com/deis/controller-sdk-go/domains"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/pkg/logging"
-	"github.com/deis/workflow-cli/pkg/webbrowser"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/apps"
+	"github.com/teamhephy/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/domains"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/pkg/logging"
+	"github.com/teamhephy/workflow-cli/pkg/webbrowser"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // AppCreate creates an app.
@@ -51,7 +51,7 @@ func (d *DeisCmd) AppCreate(id, buildpack, remote string, noRemote bool) error {
 		if err = git.CreateRemote(git.DefaultCmd, s.Client.ControllerURL.Host, remote, app.ID); err != nil {
 			if strings.Contains(err.Error(), fmt.Sprintf("fatal: remote %s already exists.", remote)) {
 				msg := "A git remote with the name %s already exists. To overwrite this remote run:\n"
-				msg += "deis git:remote --force --remote %s --app %s"
+				msg += "hephy git:remote --force --remote %s --app %s"
 				return fmt.Errorf(msg, remote, remote, app.ID)
 			}
 			return err
@@ -61,7 +61,7 @@ func (d *DeisCmd) AppCreate(id, buildpack, remote string, noRemote bool) error {
 	}
 
 	if noRemote {
-		d.Printf("If you want to add a git remote for this app later, use `deis git:remote -a %s`\n", app.ID)
+		d.Printf("If you want to add a git remote for this app later, use `hephy git:remote -a %s`\n", app.ID)
 	}
 
 	return nil

--- a/cmd/apps_test.go
+++ b/cmd/apps_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/arschles/assert"
 
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/pkg/testutil"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 type expandURLCases struct {
@@ -292,7 +292,7 @@ func TestExpandUrl(t *testing.T) {
 	}
 
 	for _, check := range checks {
-		out := expandURL("deis.foo.com", check.Input)
+		out := expandURL("hephy.foo.com", check.Input)
 
 		if out != check.Expected {
 			t.Errorf("Expected %s, Got %s", check.Expected, out)
@@ -327,14 +327,14 @@ func TestRemoteExists(t *testing.T) {
 	assert.NoErr(t, os.Chdir(dir))
 
 	assert.NoErr(t, git.Init(git.DefaultCmd))
-	assert.NoErr(t, git.CreateRemote(git.DefaultCmd, "localhost", "deis", "appname"))
+	assert.NoErr(t, git.CreateRemote(git.DefaultCmd, "localhost", "hephy", "appname"))
 
 	var b bytes.Buffer
 	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
 
-	err = cmdr.AppCreate("foo", "", "deis", false)
+	err = cmdr.AppCreate("foo", "", "hephy", false)
 
-	assert.Equal(t, err.Error(), `A git remote with the name deis already exists. To overwrite this remote run:
-deis git:remote --force --remote deis --app foo`,
+	assert.Equal(t, err.Error(), `A git remote with the name hephy already exists. To overwrite this remote run:
+hephy git:remote --force --remote hephy --app foo`,
 		"output")
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"syscall"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/auth"
-	"github.com/deis/workflow-cli/settings"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/auth"
+	"github.com/teamhephy/workflow-cli/settings"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestRegister(t *testing.T) {

--- a/cmd/autoscale.go
+++ b/cmd/autoscale.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // AutoscaleList tells the informations about app's autoscale status

--- a/cmd/autoscale_test.go
+++ b/cmd/autoscale_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestAutoscaleList(t *testing.T) {

--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -6,7 +6,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/deis/controller-sdk-go/builds"
+	"github.com/teamhephy/controller-sdk-go/builds"
 )
 
 // BuildsList lists an app's builds.

--- a/cmd/builds_test.go
+++ b/cmd/builds_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestParseProcfile(t *testing.T) {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/certs"
-	dtime "github.com/deis/controller-sdk-go/pkg/time"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/certs"
+	dtime "github.com/teamhephy/controller-sdk-go/pkg/time"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 const dateFormat = "2 Jan 2006"

--- a/cmd/certs_test.go
+++ b/cmd/certs_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestCertsList(t *testing.T) {
@@ -71,12 +71,12 @@ func TestCertsList(t *testing.T) {
 	err = cmdr.CertsList(-1, time.Date(2016, time.June, 9, 0, 0, 0, 0, time.UTC))
 	assert.NoErr(t, err)
 
-	assert.Equal(t, b.String(), `        Name       |   Common Name    |    SubjectAltName    |         Expires          |   Fingerprint   |       Domains        |  Updated   |  Created    
+	assert.Equal(t, b.String(), `        Name       |   Common Name    |    SubjectAltName    |         Expires          |   Fingerprint   |       Domains        |  Updated   |  Created
 +------------------+------------------+----------------------+--------------------------+-----------------+----------------------+------------+------------+
-  test-example-com | test.example.com | test.com,example.com | 10 Nov 2014 (expired)    | 12:34[...]78:90 | test.com,example.com | 9 Jun 2016 | 9 Jun 2016  
-  test-deis-com    | test.deis.com    |                      | 1 Aug 2016 (in 2 months) | ab:12[...]12:ab |                      | 9 Jun 2016 | 9 Jun 2016  
-  test1            | 1.test.deis.com  |                      | 11 Jun 2016 (in 2 days)  |                 |                      | unknown    | unknown     
-  test2            | 2.test.deis.com  |                      | 1 Jan 2018 (in 2 years)  |                 |                      | unknown    | unknown     
+  test-example-com | test.example.com | test.com,example.com | 10 Nov 2014 (expired)    | 12:34[...]78:90 | test.com,example.com | 9 Jun 2016 | 9 Jun 2016
+  test-deis-com    | test.deis.com    |                      | 1 Aug 2016 (in 2 months) | ab:12[...]12:ab |                      | 9 Jun 2016 | 9 Jun 2016
+  test1            | 1.test.deis.com  |                      | 11 Jun 2016 (in 2 days)  |                 |                      | unknown    | unknown
+  test2            | 2.test.deis.com  |                      | 1 Jan 2018 (in 2 years)  |                 |                      | unknown    | unknown
 `, "output")
 
 	cf, server, err = testutil.NewTestServerAndClient()
@@ -144,9 +144,9 @@ func TestCertsListLimit(t *testing.T) {
 	err = cmdr.CertsList(1, time.Date(2016, time.June, 9, 0, 0, 0, 0, time.UTC))
 	assert.NoErr(t, err)
 
-	assert.Equal(t, b.String(), `        Name       |   Common Name    |    SubjectAltName    |        Expires        |   Fingerprint   |       Domains        |  Updated   |  Created    
+	assert.Equal(t, b.String(), `        Name       |   Common Name    |    SubjectAltName    |        Expires        |   Fingerprint   |       Domains        |  Updated   |  Created
 +------------------+------------------+----------------------+-----------------------+-----------------+----------------------+------------+------------+
-  test-example-com | test.example.com | test.com,example.com | 10 Nov 2014 (expired) | 12:34[...]78:90 | test.com,example.com | 9 Jun 2016 | 9 Jun 2016  
+  test-example-com | test.example.com | test.com,example.com | 10 Nov 2014 (expired) | 12:34[...]78:90 | test.com,example.com | 9 Jun 2016 | 9 Jun 2016
 `, "output")
 
 }
@@ -213,16 +213,16 @@ Updated:            9 Jun 2016
 	err = cmdr.CertInfo("test-deis-com")
 	assert.NoErr(t, err)
 	assert.Equal(t, b.String(), `=== test-deis-com Certificate
-Common Name(s):     
+Common Name(s):
 Expires At:         unknown
 Starts At:          unknown
-Fingerprint:        
+Fingerprint:
 Subject Alt Name:   N/A
-Issuer:             
-Subject:            
+Issuer:
+Subject:
 
 Connected Domains:  No connected domains
-Owner:              
+Owner:
 Created:            unknown
 Updated:            unknown
 `, "output")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/deis/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // Commander is interface definition for running commands

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // ConfigList lists an app's config.
@@ -88,9 +88,9 @@ func (d *DeisCmd) ConfigSet(appID string, configVars []string) error {
 	// send them a deprecation notice.
 	for key := range configMap {
 		if strings.Contains(key, "HEALTHCHECK_") {
-			d.Println(`Hey there! We've noticed that you're using 'deis config:set HEALTHCHECK_URL'
+			d.Println(`Hey there! We've noticed that you're using 'hephy config:set HEALTHCHECK_URL'
 to set up healthchecks. This functionality has been deprecated. In the future, please use
-'deis healthchecks' to set up application health checks. Thanks!`)
+'hephy healthchecks' to set up application health checks. Thanks!`)
 		}
 	}
 
@@ -283,7 +283,7 @@ func parseSSHKey(value string) (string, error) {
 	}
 
 	// NOTE(felixbuenemann): check if the current value is already a base64 encoded key.
-	// This is the case if it was fetched using "deis config:pull".
+	// This is the case if it was fetched using "hephy config:pull".
 	contents, err := base64.StdEncoding.DecodeString(value)
 
 	if err == nil && sshRegex.MatchString(string(contents)) {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestParseConfig(t *testing.T) {

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/deis/controller-sdk-go/domains"
+import "github.com/teamhephy/controller-sdk-go/domains"
 
 // DomainsList lists domains registered with an app.
 func (d *DeisCmd) DomainsList(appID string, results int) error {

--- a/cmd/domains_test.go
+++ b/cmd/domains_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestDomainsList(t *testing.T) {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/pkg/git"
 )
 
 const remoteCreationMsg = "Git remote %s successfully created for app %s.\n"
@@ -53,7 +53,7 @@ func (d *DeisCmd) GitRemote(appID, remote string, force bool) error {
 		return nil
 	}
 
-	msg := "Remote %s already exists, please run 'deis git:remote -f' to overwrite\n"
+	msg := "Remote %s already exists, please run 'hephy git:remote -f' to overwrite\n"
 	msg += "Existing remote URL: %s\n"
 	msg += "When forced, will overwrite with: %s"
 

--- a/cmd/healthchecks.go
+++ b/cmd/healthchecks.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"sort"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 func (d *DeisCmd) printHealthCheck(healthcheck api.Healthchecks) {

--- a/cmd/healthchecks_test.go
+++ b/cmd/healthchecks_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestPrintHealthCheck(t *testing.T) {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/keys"
-	"github.com/deis/workflow-cli/pkg/ssh"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/keys"
+	"github.com/teamhephy/workflow-cli/pkg/ssh"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // KeysList lists a user's keys.
@@ -104,7 +104,7 @@ func (d *DeisCmd) KeyAdd(name string, keyLocation string) error {
 		key.ID = name
 	}
 
-	d.Printf("Uploading %s to deis...", filepath.Base(key.Name))
+	d.Printf("Uploading %s to hephy...", filepath.Base(key.Name))
 
 	if _, err = keys.New(s.Client, key.ID, key.Public); d.checkAPICompatibility(s.Client, err) != nil {
 		d.Println()

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -12,15 +12,15 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 func TestGetKey(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "deis-key")
+	file, err := ioutil.TempFile("", "hephy-key")
 	assert.NoErr(t, err)
 
 	toWrite := []byte("ssh-rsa abc test@example.com")
@@ -46,7 +46,7 @@ func TestGetKey(t *testing.T) {
 func TestGetKeyNoComment(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "deis-key")
+	file, err := ioutil.TempFile("", "hephy-key")
 	assert.NoErr(t, err)
 
 	toWrite := []byte("ssh-rsa abc")
@@ -69,7 +69,7 @@ func TestGetKeyNoComment(t *testing.T) {
 func TestGetInvalidKey(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "deis-key")
+	file, err := ioutil.TempFile("", "hephy-key")
 	assert.NoErr(t, err)
 
 	toWrite := []byte("not a key")
@@ -83,7 +83,7 @@ func TestGetInvalidKey(t *testing.T) {
 }
 
 func TestListKeys(t *testing.T) {
-	name, err := ioutil.TempDir("", "deis-key")
+	name, err := ioutil.TempDir("", "hephy-key")
 	assert.NoErr(t, err)
 	settings.SetHome(name)
 
@@ -139,7 +139,7 @@ type chooseKeyCases struct {
 func TestChooseKey(t *testing.T) {
 	t.Parallel()
 
-	file, err := ioutil.TempFile("", "deis-key")
+	file, err := ioutil.TempFile("", "hephy-key")
 	assert.NoErr(t, err)
 	toWrite := []byte("ssh-rsa abc test@example.com")
 	_, err = file.Write(toWrite)
@@ -299,7 +299,7 @@ func TestKeyRemove(t *testing.T) {
 
 func TestKeyAdd(t *testing.T) {
 	// Set temp home dir so no unknown files are listed.
-	name, err := ioutil.TempDir("", "deis-key")
+	name, err := ioutil.TempDir("", "hephy-key")
 	assert.NoErr(t, err)
 	settings.SetHome(name)
 	folder := filepath.Join(name, ".ssh")
@@ -314,7 +314,7 @@ func TestKeyAdd(t *testing.T) {
 	var b bytes.Buffer
 	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
 
-	keyFile, err := ioutil.TempFile("", "deis-cli-unit-test-ssh-key")
+	keyFile, err := ioutil.TempFile("", "hephy-cli-unit-test-ssh-key")
 	assert.NoErr(t, err)
 	toWrite := []byte("ssh-rsa abc test@example.com")
 	_, err = keyFile.Write(toWrite)
@@ -328,7 +328,7 @@ func TestKeyAdd(t *testing.T) {
 		fmt.Fprintf(w, "{}")
 	})
 
-	out := fmt.Sprintf("Uploading %s to deis... done\n", filepath.Base(keyFile.Name()))
+	out := fmt.Sprintf("Uploading %s to hephy... done\n", filepath.Base(keyFile.Name()))
 
 	err = cmdr.KeyAdd("", keyFile.Name())
 	assert.NoErr(t, err)
@@ -345,7 +345,7 @@ Which would you like to use with Deis? Enter the path to the pubkey file: `+out,
 
 func TestKeyAddName(t *testing.T) {
 	// Set temp home dir so no unknown files are listed.
-	name, err := ioutil.TempDir("", "deis-key")
+	name, err := ioutil.TempDir("", "hephy-key")
 	assert.NoErr(t, err)
 	settings.SetHome(name)
 	folder := filepath.Join(name, ".ssh")
@@ -360,7 +360,7 @@ func TestKeyAddName(t *testing.T) {
 	var b bytes.Buffer
 	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
 
-	keyFile, err := ioutil.TempFile("", "deis-cli-unit-test-ssh-key")
+	keyFile, err := ioutil.TempFile("", "hephy-cli-unit-test-ssh-key")
 	assert.NoErr(t, err)
 	// generate with one name but used another in the add
 	toWrite := []byte("ssh-rsa abc test@example.com")
@@ -370,14 +370,14 @@ func TestKeyAddName(t *testing.T) {
 
 	server.Mux.HandleFunc("/v2/keys/", func(w http.ResponseWriter, r *http.Request) {
 		testutil.SetHeaders(w)
-		testutil.AssertBody(t, api.KeyCreateRequest{ID: "deis-test-key", Public: string(toWrite)}, r)
+		testutil.AssertBody(t, api.KeyCreateRequest{ID: "hephy-test-key", Public: string(toWrite)}, r)
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, "{}")
 	})
 
-	out := fmt.Sprintf("Uploading %s to deis... done\n", filepath.Base(keyFile.Name()))
+	out := fmt.Sprintf("Uploading %s to hephy... done\n", filepath.Base(keyFile.Name()))
 
-	err = cmdr.KeyAdd("deis-test-key", keyFile.Name())
+	err = cmdr.KeyAdd("hephy-test-key", keyFile.Name())
 	assert.NoErr(t, err)
 	assert.Equal(t, testutil.StripProgress(b.String()), out, "output")
 }

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // LabelsList list app's labels

--- a/cmd/labels_test.go
+++ b/cmd/labels_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 	"strings"
 )
 

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // LimitsList lists an app's limits.

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 type parseLimitCase struct {

--- a/cmd/maintenance.go
+++ b/cmd/maintenance.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // MaintenanceInfo tells the informations about app's maintenance status

--- a/cmd/maintenance_test.go
+++ b/cmd/maintenance_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestMaintenanceInfo(t *testing.T) {

--- a/cmd/perms.go
+++ b/cmd/perms.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/perms"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/perms"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // PermsList prints which users have permissions.

--- a/cmd/perms_test.go
+++ b/cmd/perms_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestPermsListUsers(t *testing.T) {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/ps"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/ps"
 )
 
 // PsList lists an app's processes.

--- a/cmd/ps_test.go
+++ b/cmd/ps_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/pkg/time"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/pkg/time"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestParseType(t *testing.T) {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // RegistryList lists an app's registry information.

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 type parseInfoCase struct {

--- a/cmd/releases.go
+++ b/cmd/releases.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/deis/controller-sdk-go/releases"
+	"github.com/teamhephy/controller-sdk-go/releases"
 )
 
 // ReleasesList lists an app's releases.

--- a/cmd/releases_test.go
+++ b/cmd/releases_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestReleasesList(t *testing.T) {

--- a/cmd/routing.go
+++ b/cmd/routing.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // RoutingInfo provides information about the status of app routing.

--- a/cmd/routing_test.go
+++ b/cmd/routing_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestRoutingInfo(t *testing.T) {

--- a/cmd/shortcuts.go
+++ b/cmd/shortcuts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/deis/workflow-cli/cli"
+	"github.com/teamhephy/workflow-cli/cli"
 )
 
 // ShortcutsList displays all relevant shortcuts for the CLI.

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // TagsList lists an app's tags.

--- a/cmd/tags_test.go
+++ b/cmd/tags_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 type parseTagCase struct {

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/deis/controller-sdk-go/tls"
+import "github.com/teamhephy/controller-sdk-go/tls"
 
 // TLSInfo prints info about the TLS settings for the given app.
 func (d *DeisCmd) TLSInfo(appID string) error {

--- a/cmd/tls_test.go
+++ b/cmd/tls_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestTLSInfo(t *testing.T) {

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/users"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/users"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // UsersList lists users registered with the controller.

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestUsersList(t *testing.T) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/settings"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 var defaultLimit = -1

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 func TestLoad(t *testing.T) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/settings"
-	"github.com/deis/workflow-cli/version"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/settings"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 // Version prints the various CLI versions.

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/pkg/testutil"
-	"github.com/deis/workflow-cli/version"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 func TestVersion(t *testing.T) {

--- a/cmd/whitelist.go
+++ b/cmd/whitelist.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"strings"
 
-	"github.com/deis/controller-sdk-go/whitelist"
+	"github.com/teamhephy/controller-sdk-go/whitelist"
 )
 
 // WhitelistList lists the addresses whitelisted for app

--- a/cmd/whitelist_test.go
+++ b/cmd/whitelist_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestWhitelistList(t *testing.T) {

--- a/deis.go
+++ b/deis.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/deis/workflow-cli/cli"
-	"github.com/deis/workflow-cli/cmd"
-	"github.com/deis/workflow-cli/parser"
+	"github.com/teamhephy/workflow-cli/cli"
+	"github.com/teamhephy/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/parser"
 	docopt "github.com/docopt/docopt-go"
 )
 
-const extensionPrefix = "deis-"
+const extensionPrefix = "hephy-"
 
 // main exits with the return value of Command(os.Args[1:]), deferring all logic to
 // a func we can test.
@@ -25,9 +25,9 @@ func main() {
 // Command routes deis commands to their proper parser.
 func Command(argv []string, wOut io.Writer, wErr io.Writer, wIn io.Reader) int {
 	usage := `
-The Deis command-line client issues API calls to a Deis controller.
+The Hephy command-line client issues API calls to a Hephy controller.
 
-Usage: deis <command> [<args>...]
+Usage: hephy <command> [<args>...]
 
 Options:
   -h --help
@@ -36,16 +36,16 @@ Options:
     display client version
   -c --config=<config>
     path to configuration file. Equivalent to
-    setting $DEIS_PROFILE. Defaults to ~/.deis/config.json.
-    If value is not a filepath, will assume location ~/.deis/client.json
+    setting $DEIS_PROFILE. Defaults to ~/.hephy/config.json.
+    If value is not a filepath, will assume location ~/.hephy/client.json
 
-Auth commands, use 'deis help auth' to learn more::
+Auth commands, use 'hephy help auth' to learn more::
 
   register      register a new user with a controller
   login         login to a controller
   logout        logout from the current controller
 
-Subcommands, use 'deis help [subcommand]' to learn more::
+Subcommands, use 'hephy help [subcommand]' to learn more::
 
   apps          manage applications used to provide services
   autoscale     manage autoscale for applications
@@ -70,7 +70,7 @@ Subcommands, use 'deis help [subcommand]' to learn more::
   version       display client version
   whitelist     manage whitelisted addresses of an application
 
-Shortcut commands, use 'deis shortcuts' to see all::
+Shortcut commands, use 'hephy shortcuts' to see all::
 
   create        create a new application
   destroy       destroy an application
@@ -81,7 +81,7 @@ Shortcut commands, use 'deis shortcuts' to see all::
   run           run a command in an ephemeral app container
   scale         scale processes by type (web=2, worker=1)
 
-Use 'git push deis master' to deploy to an application.
+Use 'git push hephy master' to deploy to an application.
 `
 	// Reorganize some command line flags and commands.
 	command, argv := parseArgs(argv)
@@ -94,7 +94,7 @@ Use 'git push deis master' to deploy to an application.
 	}
 
 	if len(argv) == 0 {
-		fmt.Fprintln(wErr, "Usage: deis <command> [<args>...]")
+		fmt.Fprintln(wErr, "Usage: hephy <command> [<args>...]")
 		return 1
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -3,7 +3,7 @@ updated: 2017-01-09T11:54:15.635074917-08:00
 imports:
 - name: github.com/arschles/assert
   version: bb58b908265b5931732079df03f2818bf2167ba0
-- name: github.com/deis/controller-sdk-go
+- name: github.com/teamhephy/controller-sdk-go
   version: 9520b6c460202f376856d042ac4864ee951cdf3a
   subpackages:
   - api
@@ -22,7 +22,7 @@ imports:
   - tls
   - users
   - whitelist
-- name: github.com/deis/pkg
+- name: github.com/teamhephy/pkg
   version: 28bd07fbcbec5aaaaeda05d362d8ff81f55f4f6c
   subpackages:
   - prettyprint

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,11 +1,11 @@
-package: github.com/deis/workflow-cli
+package: github.com/teamhephy/workflow-cli
 ignore:
 - appengine
 - appengine/user
 - appengine/datastore
 - appengine/memcache
 import:
-- package: github.com/deis/pkg
+- package: github.com/teamhephy/pkg
   subpackages:
   - time
 - package: github.com/docopt/docopt-go
@@ -15,5 +15,5 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/olekukonko/tablewriter
 - package: github.com/arschles/assert
-- package: github.com/deis/controller-sdk-go
+- package: github.com/teamhephy/controller-sdk-go
   version: 9520b6c460202f376856d042ac4864ee951cdf3a

--- a/make.ps1
+++ b/make.ps1
@@ -1,5 +1,5 @@
 if ($args[0] -eq "build") {
-  go build -a -installsuffix cgo -ldflags "-s -X github.com/deis/workflow-cli/version.BuildVersion=$(git rev-parse --short HEAD)" -o deis.exe .
+  go build -a -installsuffix cgo -ldflags "-s -X github.com/teamhephy/workflow-cli/version.BuildVersion=$(git rev-parse --short HEAD)" -o hephy.exe .
 } elseif ($args[0] -eq "test") {
   go test --cover --race -v $(glide novendor)
 } elseif ($args[0] -eq "bootstrap") {

--- a/parser/apps.go
+++ b/parser/apps.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -22,7 +22,7 @@ apps:run           run a command in an ephemeral app container
 apps:destroy       destroy an application
 apps:transfer      transfer app ownership to another user
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -63,7 +63,7 @@ Creates a new application.
 
 - if no <id> is provided, one will be generated automatically.
 
-Usage: deis apps:create [<id>] [options]
+Usage: hephy apps:create [<id>] [options]
 
 Arguments:
   <id>
@@ -72,11 +72,11 @@ Arguments:
 
 Options:
   --no-remote
-    do not create a 'deis' git remote.
+    do not create a 'hephy' git remote.
   -b --buildpack BUILDPACK
     a buildpack url to use for this app
   -r --remote REMOTE
-    name of remote to create. [default: deis]
+    name of remote to create. [default: hephy]
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -97,7 +97,7 @@ func appsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists applications visible to the current user.
 
-Usage: deis apps:list [options]
+Usage: hephy apps:list [options]
 
 Options:
   -l --limit=<num>
@@ -123,7 +123,7 @@ func appInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application.
 
-Usage: deis apps:info [options]
+Usage: hephy apps:info [options]
 
 Options:
   -a --app=<app>
@@ -145,7 +145,7 @@ func appOpen(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Opens a URL to the application in the default browser.
 
-Usage: deis apps:open [options]
+Usage: hephy apps:open [options]
 
 Options:
   -a --app=<app>
@@ -167,7 +167,7 @@ func appLogs(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Retrieves the most recent log events.
 
-Usage: deis apps:logs [options]
+Usage: hephy apps:logs [options]
 
 Options:
   -a --app=<app>
@@ -205,7 +205,7 @@ func appRun(argv []string, cmdr cmd.Commander) error {
 Runs a command inside an ephemeral app container. Default environment is
 /bin/bash.
 
-Usage: deis apps:run [options] [--] <command>...
+Usage: hephy apps:run [options] [--] <command>...
 
 Arguments:
   <command>
@@ -232,7 +232,7 @@ func appDestroy(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Destroys an application.
 
-Usage: deis apps:destroy [options]
+Usage: hephy apps:destroy [options]
 
 Options:
   -a --app=<app>
@@ -258,7 +258,7 @@ func appTransfer(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Transfer app ownership to another user.
 
-Usage: deis apps:transfer <username> [options]
+Usage: hephy apps:transfer <username> [options]
 
 Arguments:
   <username>

--- a/parser/apps_test.go
+++ b/parser/apps_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/auth.go
+++ b/parser/auth.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -20,7 +20,7 @@ auth:whoami            display the current user
 auth:cancel            remove the current user account
 auth:regenerate        regenerate user tokens
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -51,7 +51,7 @@ func authRegister(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Registers a new user with a Deis controller.
 
-Usage: deis auth:register <controller> [options]
+Usage: hephy auth:register <controller> [options]
 
 Arguments:
   <controller>
@@ -102,7 +102,7 @@ func authLogin(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Logs in by authenticating against a controller.
 
-Usage: deis auth:login <controller> [options]
+Usage: hephy auth:login <controller> [options]
 
 Arguments:
   <controller>
@@ -139,7 +139,7 @@ func authLogout(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Logs out from a controller and clears the user session.
 
-Usage: deis auth:logout
+Usage: hephy auth:logout
 
 Options:
 `
@@ -155,7 +155,7 @@ func authPasswd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Changes the password for the current user.
 
-Usage: deis auth:passwd [options]
+Usage: hephy auth:passwd [options]
 
 Options:
   --password=<password>
@@ -183,7 +183,7 @@ func authWhoami(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Displays the currently logged in user.
 
-Usage: deis auth:whoami [options]
+Usage: hephy auth:whoami [options]
 
 Options:
   --all
@@ -203,7 +203,7 @@ func authCancel(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Cancels and removes the current account.
 
-Usage: deis auth:cancel [options]
+Usage: hephy auth:cancel [options]
 
 Options:
   --username=<username>
@@ -231,7 +231,7 @@ func authRegenerate(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Regenerates auth token, defaults to regenerating token for the current user.
 
-Usage: deis auth:regenerate [options]
+Usage: hephy auth:regenerate [options]
 
 Options:
   -u --username=<username>

--- a/parser/auth_test.go
+++ b/parser/auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/autoscale.go
+++ b/parser/autoscale.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ autoscale:list   list autoscale options of an application
 autoscale:set    turn on autoscale for an app
 autoscale:unset  turn off autoscale for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func autoscaleList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints a list of autoscale options for the application.
 
-Usage: deis autoscale:list [options]
+Usage: hephy autoscale:list [options]
 
 Options:
   -a --app=<app>
@@ -63,7 +63,7 @@ func autoscaleSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Set autoscale option per process type for an app.
 
-Usage: deis autoscale:set <process-type> --min=<min> --max=<max> --cpu-percent=<percent> [options]
+Usage: hephy autoscale:set <process-type> --min=<min> --max=<max> --cpu-percent=<percent> [options]
 
 Arguments:
   <process-type>
@@ -99,7 +99,7 @@ func autoscaleUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unset autoscale per process type for an app.
 
-Usage: deis autoscale:unset <process-type> [options]
+Usage: hephy autoscale:unset <process-type> [options]
 
 Arguments:
   <process-type>

--- a/parser/autoscale_test.go
+++ b/parser/autoscale_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/builds.go
+++ b/parser/builds.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/builds_test.go
+++ b/parser/builds_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func (d FakeDeisCmd) BuildsList(string, int) error {

--- a/parser/certs.go
+++ b/parser/certs.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"time"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/certs_test.go
+++ b/parser/certs_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/config.go
+++ b/parser/config.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -16,7 +16,7 @@ config:unset       unset environment variables for an app
 config:pull        extract environment variables to .env
 config:push        set environment variables from .env
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -49,7 +49,7 @@ func configList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists environment variables for an application.
 
-Usage: deis config:list [options]
+Usage: hephy config:list [options]
 
 Options:
   --oneline
@@ -83,7 +83,7 @@ func configSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets environment variables for an application.
 
-Usage: deis config:set <var>=<value> [<var>=<value>...] [options]
+Usage: hephy config:set <var>=<value> [<var>=<value>...] [options]
 
 Arguments:
   <var>
@@ -111,7 +111,7 @@ func configUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets an environment variable for an application.
 
-Usage: deis config:unset <key>... [options]
+Usage: hephy config:unset <key>... [options]
 
 Arguments:
   <key>
@@ -136,11 +136,11 @@ func configPull(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Extract all environment variables from an application for local use.
 
-The environmental variables can be piped into a file, 'deis config:pull > file',
+The environmental variables can be piped into a file, 'hephy config:pull > file',
 or stored locally in a file named .env. This file can be
 read by foreman to load the local environment for your app.
 
-Usage: deis config:pull [options]
+Usage: hephy config:pull [options]
 
 Options:
   -a --app=<app>
@@ -170,9 +170,9 @@ Sets environment variables for an application.
 
 This file can be read by foreman
 to load the local environment for your app. The file should be piped via
-stdin, 'deis config:push < .env', or using the --path option.
+stdin, 'hephy config:push < .env', or using the --path option.
 
-Usage: deis config:push [options]
+Usage: hephy config:push [options]
 
 Options:
   -a --app=<app>

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/domains.go
+++ b/parser/domains.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ domains:add           bind a domain to an application
 domains:list          list domains bound to an application
 domains:remove        unbind a domain from an application
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func domainsAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Binds a domain to an application.
 
-Usage: deis domains:add <domain> [options]
+Usage: hephy domains:add <domain> [options]
 
 Arguments:
   <domain>
@@ -70,7 +70,7 @@ func domainsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists domains bound to an application.
 
-Usage: deis domains:list [options]
+Usage: hephy domains:list [options]
 
 Options:
   -a --app=<app>
@@ -99,7 +99,7 @@ func domainsRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unbinds a domain for an application.
 
-Usage: deis domains:remove <domain> [options]
+Usage: hephy domains:remove <domain> [options]
 
 Arguments:
   <domain>

--- a/parser/domains_test.go
+++ b/parser/domains_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/git.go
+++ b/parser/git.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -15,7 +15,7 @@ Valid commands for git:
 git:remote          Adds git remote of application to repository
 git:remove          Removes git remote of application from repository
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -36,13 +36,13 @@ func gitRemote(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Adds git remote of application to repository
 
-Usage: deis git:remote [options]
+Usage: hephy git:remote [options]
 
 Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
   -r --remote=REMOTE
-    name of remote to create. [default: deis]
+    name of remote to create. [default: hephy]
   -f --force
     overwrite remote of the given name if it already exists.
 `
@@ -64,7 +64,7 @@ func gitRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Removes git remotes of application from repository.
 
-Usage: deis git:remove [options]
+Usage: hephy git:remove [options]
 
 Options:
   -a --app=<app>

--- a/parser/git_test.go
+++ b/parser/git_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/healthchecks.go
+++ b/parser/healthchecks.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 
-	"github.com/deis/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/api"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -26,7 +26,7 @@ healthchecks:list        list healthchecks for an app
 healthchecks:set         set healthchecks for an app
 healthchecks:unset       unset healthchecks for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -55,7 +55,7 @@ func healthchecksList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists healthchecks for an application.
 
-Usage: deis healthchecks:list [options]
+Usage: hephy healthchecks:list [options]
 
 Options:
   -a --app=<app>
@@ -106,7 +106,7 @@ probes accept a string of arguments to be run inside the Container.
 considered healthy if the check can establish a connection. 'tcpSocket' probes accept a
 port number to perform the socket connection on the Container.
 
-Usage: deis healthchecks:set <health-type> <probe-type> [options] [--] <args>...
+Usage: hephy healthchecks:set <health-type> <probe-type> [options] [--] <args>...
 
 Arguments:
   <health-type>
@@ -218,7 +218,7 @@ func healthchecksUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets healthchecks for an application.
 
-Usage: deis healthchecks:unset [options] <health-type>...
+Usage: hephy healthchecks:unset [options] <health-type>...
 
 Arguments:
   <health-type>

--- a/parser/healthchecks_test.go
+++ b/parser/healthchecks_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/keys.go
+++ b/parser/keys.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ keys:list        list SSH keys for the logged in user
 keys:add         add an SSH key
 keys:remove      remove an SSH key
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func keysList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists SSH keys for the logged in user.
 
-Usage: deis keys:list [options]
+Usage: hephy keys:list [options]
 
 Options:
   -l --limit=<num>
@@ -69,7 +69,7 @@ func keyAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Adds SSH keys for the logged in user.
 
-Usage: deis keys:add [<name>] [<key>]
+Usage: hephy keys:add [<name>] [<key>]
 
 <name> and <key> can be used in either order and are both optional
 
@@ -92,7 +92,7 @@ func keyRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Removes an SSH key for the logged in user.
 
-Usage: deis keys:remove <key>
+Usage: hephy keys:remove <key>
 
 Arguments:
   <key>

--- a/parser/keys_test.go
+++ b/parser/keys_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/labels.go
+++ b/parser/labels.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ labels:list   list application's labels
 labels:set    add new application's label
 labels:unset  remove application's label
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func labelsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints a list of labels of the application.
 
-Usage: deis labels:list [options]
+Usage: hephy labels:list [options]
 
 Options:
   -a --app=<app>
@@ -63,10 +63,10 @@ func labelsSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets labels for an application.
 
-A label is a key/value pair used to label an application. This label is a general information for deis user.
+A label is a key/value pair used to label an application. This label is a general information for hephy user.
 Mostly used for administration/maintenance information, note for application. This information isn't send to scheduler.
 
-Usage: deis labels:set [options] <key>=<value>...
+Usage: hephy labels:set [options] <key>=<value>...
 
 Arguments:
   <key> the label key, for example: "git_repo" or "team"
@@ -92,7 +92,7 @@ func labelsUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets labels for an application.
 
-Usage: deis labels:unset [options] <key>...
+Usage: hephy labels:unset [options] <key>...
 
 Arguments:
   <key> the label key to unset, for example: "git_repo" or "team"

--- a/parser/labels_test.go
+++ b/parser/labels_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument
@@ -46,7 +46,7 @@ func TestLabels(t *testing.T) {
 			expected: "",
 		},
 		{
-			args:     []string{"labels:set", "git_repo=https://github.com/teamhephy/workflow", "team=deis"},
+			args:     []string{"labels:set", "git_repo=https://github.com/teamhephy/workflow", "team=teamhephy"},
 			expected: "",
 		},
 		{

--- a/parser/limits.go
+++ b/parser/limits.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ limits:list        list resource limits for an app
 limits:set         set resource limits for an app
 limits:unset       unset resource limits for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func limitsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists resource limits for an application.
 
-Usage: deis limits:list [options]
+Usage: hephy limits:list [options]
 
 Options:
   -a --app=<app>
@@ -70,7 +70,7 @@ it'll be default by Kubernetes as both request and limit. These request and limi
 are applied to each individual pod, so setting a memory limit of 1G for an application
 means that each pod gets 1G of memory. Value needs to be within 0 <= request <= limit
 
-Usage: deis limits:set [options] <type>=<value>...
+Usage: hephy limits:set [options] <type>=<value>...
 
 Arguments:
   <type>
@@ -82,13 +82,13 @@ Arguments:
     You can only set one type of limit per call.
 
     With --memory, units are represented in Bytes (B), Kilobytes (K), Megabytes
-    (M), or Gigabytes (G). For example, 'deis limit:set cmd=1G' will restrict all
+    (M), or Gigabytes (G). For example, 'hephy limit:set cmd=1G' will restrict all
     "cmd" processes to a maximum of 1 Gigabyte of memory each.
 
     With --cpu, units are represented in the number of CPUs. For example,
-    'deis limit:set --cpu cmd=1' will restrict all "cmd" processes to a
+    'hephy limit:set --cpu cmd=1' will restrict all "cmd" processes to a
     maximum of 1 CPU. Alternatively, you can also use milli units to specify the
-    number of CPU shares the pod can use. For example, 'deis limits:set --cpu cmd=500m'
+    number of CPU shares the pod can use. For example, 'hephy limits:set --cpu cmd=500m'
     will restrict all "cmd" processes to half of a CPU.
 
 Options:
@@ -121,7 +121,7 @@ func limitUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets resource limits for an application.
 
-Usage: deis limits:unset [options] [--memory | --cpu] <type>...
+Usage: hephy limits:unset [options] [--memory | --cpu] <type>...
 
 Arguments:
   <type>

--- a/parser/limits_test.go
+++ b/parser/limits_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/maintenance.go
+++ b/parser/maintenance.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ maintenance:info   view maintenance mode of an application
 maintenance:on     turn on maintenance for an app
 maintenance:off    turn off maintenance for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func maintenanceInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application's maintenance state.
 
-Usage: deis maintenance:info [options]
+Usage: hephy maintenance:info [options]
 
 Options:
   -a --app=<app>
@@ -63,7 +63,7 @@ func maintenanceEnable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Enables maintenance mode for an app.
 
-Usage: deis maintenance:on [options]
+Usage: hephy maintenance:on [options]
 
 Options:
   -a --app=<app>
@@ -83,7 +83,7 @@ func maintenanceDisable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Disables maintenance mode for an app.
 
-Usage: deis maintenance:off [options]
+Usage: hephy maintenance:off [options]
 
 Options:
   -a --app=<app>

--- a/parser/maintenance_test.go
+++ b/parser/maintenance_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/perms.go
+++ b/parser/perms.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ perms:list            list permissions granted on an app
 perms:create          create a new permission for a user
 perms:delete          delete a permission for a user
 
-Use 'deis help perms:[command]' to learn more.
+Use 'hephy help perms:[command]' to learn more.
 `
 
 	switch argv[0] {
@@ -44,7 +44,7 @@ func permsList(argv []string, cmdr cmd.Commander) error {
 Lists all users with permission to use an app, or lists all users with system
 administrator privileges.
 
-Usage: deis perms:list [-a --app=<app>|--admin|--admin --limit=<num>]
+Usage: hephy perms:list [-a --app=<app>|--admin|--admin --limit=<num>]
 
 Options:
   -a --app=<app>
@@ -78,7 +78,7 @@ func permCreate(argv []string, cmdr cmd.Commander) error {
 Gives another user permission to use an app, or gives another user
 system administrator privileges.
 
-Usage: deis perms:create <username> [-a --app=<app>|--admin]
+Usage: hephy perms:create <username> [-a --app=<app>|--admin]
 
 Arguments:
   <username>
@@ -110,7 +110,7 @@ func permDelete(argv []string, cmdr cmd.Commander) error {
 Revokes another user's permission to use an app, or revokes another user's system
 administrator privileges.
 
-Usage: deis perms:delete <username> [-a --app=<app>|--admin]
+Usage: hephy perms:delete <username> [-a --app=<app>|--admin]
 
 Arguments:
   <username>

--- a/parser/perms_test.go
+++ b/parser/perms_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/ps.go
+++ b/parser/ps.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ ps:list        list application processes
 ps:restart     restart an application or its process types
 ps:scale       scale processes (e.g. web=4 worker=2)
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func psList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists processes servicing an application.
 
-Usage: deis ps:list [options]
+Usage: hephy ps:list [options]
 
 Options:
   -a --app=<app>
@@ -63,7 +63,7 @@ func psRestart(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Restart an application, a process type or a specific process.
 
-Usage: deis ps:restart [<type>] [options]
+Usage: hephy ps:restart [<type>] [options]
 
 Arguments:
   <type>
@@ -90,7 +90,7 @@ func psScale(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Scales an application's processes by type.
 
-Usage: deis ps:scale <type>=<num>... [options]
+Usage: hephy ps:scale <type>=<num>... [options]
 
 Arguments:
   <type>

--- a/parser/ps_test.go
+++ b/parser/ps_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/registry.go
+++ b/parser/registry.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ registry:list        list registry info for an app
 registry:set         set registry info for an app
 registry:unset       unset registry info for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func registryList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists registry information for an application.
 
-Usage: deis registry:list [options]
+Usage: hephy registry:list [options]
 
 Options:
   -a --app=<app>
@@ -63,7 +63,7 @@ func registrySet(argv []string, cmdr cmd.Commander) error {
 Sets registry information for an application. These credentials are the same as those used for
 'docker login' to the private registry.
 
-Usage: deis registry:set [options] <key>=<value>...
+Usage: hephy registry:set [options] <key>=<value>...
 
 Arguments:
   <key>
@@ -93,7 +93,7 @@ func registryUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets registry information for an application.
 
-Usage: deis registry:unset [options] <key>...
+Usage: hephy registry:unset [options] <key>...
 
 Arguments:
   <key> the registry key to unset, for example: "username" or "password"

--- a/parser/registry_test.go
+++ b/parser/registry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/releases.go
+++ b/parser/releases.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -17,7 +17,7 @@ releases:list        list an application's release history
 releases:info        print information about a specific release
 releases:rollback    return to a previous release
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -46,7 +46,7 @@ func releasesList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists release history for an application.
 
-Usage: deis releases:list [options]
+Usage: hephy releases:list [options]
 
 Options:
   -a --app=<app>
@@ -74,7 +74,7 @@ func releasesInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about a particular release.
 
-Usage: deis releases:info <version> [options]
+Usage: hephy releases:info <version> [options]
 
 Arguments:
   <version>
@@ -105,7 +105,7 @@ func releasesRollback(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Rolls back to a previous application release.
 
-Usage: deis releases:rollback [<version>] [options]
+Usage: hephy releases:rollback [<version>] [options]
 
 Arguments:
   <version>

--- a/parser/releases_test.go
+++ b/parser/releases_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/routing.go
+++ b/parser/routing.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ routing:info       view routability of an application
 routing:enable     enable routing for an app
 routing:disable    disable routing for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func routingInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application's routability.
 
-Usage: deis routing:info [options]
+Usage: hephy routing:info [options]
 
 Options:
   -a --app=<app>
@@ -62,7 +62,7 @@ func routingEnable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Enables routability for an app.
 
-Usage: deis routing:enable [options]
+Usage: hephy routing:enable [options]
 
 Options:
   -a --app=<app>
@@ -81,7 +81,7 @@ func routingDisable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Disables routability for an app.
 
-Usage: deis routing:disable [options]
+Usage: hephy routing:disable [options]
 
 Options:
   -a --app=<app>

--- a/parser/routing_test.go
+++ b/parser/routing_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/shortcuts.go
+++ b/parser/shortcuts.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -12,7 +12,7 @@ Valid commands for shortcuts:
 
 shortcuts:list       list all relevant shortcuts for the CLI
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -37,7 +37,7 @@ func shortcutsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists all relevant shortcuts for the CLI
 
-Usage: deis shortcuts:list
+Usage: hephy shortcuts:list
 `
 
 	_, err := docopt.Parse(usage, argv, true, "", false, true)

--- a/parser/shortcuts_test.go
+++ b/parser/shortcuts_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/tags.go
+++ b/parser/tags.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ tags:list        list tags for an app
 tags:set         set tags for an app
 tags:unset       unset tags for an app
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func tagsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists tags for an application.
 
-Usage: deis tags:list [options]
+Usage: hephy tags:list [options]
 
 Options:
   -a --app=<app>
@@ -67,7 +67,7 @@ A tag is a key/value pair used to tag an application's containers and is passed 
 scheduler. This is often used to restrict workloads to specific hosts matching the
 scheduler-configured metadata.
 
-Usage: deis tags:set [options] <key>=<value>...
+Usage: hephy tags:set [options] <key>=<value>...
 
 Arguments:
   <key> the tag key, for example: "environ" or "rack"
@@ -93,7 +93,7 @@ func tagsUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets tags for an application.
 
-Usage: deis tags:unset [options] <key>...
+Usage: hephy tags:unset [options] <key>...
 
 Arguments:
   <key> the tag key to unset, for example: "environ" or "rack"

--- a/parser/tags_test.go
+++ b/parser/tags_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/tls.go
+++ b/parser/tls.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ tls:info              view info about an application's TLS settings
 tls:enable            enables the router to enforce https-only requests to an application
 tls:disable           disables the router to enforce https-only requests to an application
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func tlsInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application's TLS settings.
 
-Usage: deis tls:info [options]
+Usage: hephy tls:info [options]
 
 Options:
   -a --app=<app>
@@ -63,7 +63,7 @@ func tlsEnable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Enable the router to enforce https-only requests to the current application.
 
-Usage: deis tls:enable [options]
+Usage: hephy tls:enable [options]
 
 Options:
   -a --app=<app>
@@ -83,7 +83,7 @@ func tlsDisable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Disable the router from enforcing https-only requests to the current application.
 
-Usage: deis tls:disable [options]
+Usage: hephy tls:disable [options]
 
 Options:
   -a --app=<app>

--- a/parser/tls_test.go
+++ b/parser/tls_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/users.go
+++ b/parser/users.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -12,7 +12,7 @@ Valid commands for users:
 
 users:list        list all registered users
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -38,7 +38,7 @@ func usersList(argv []string, cmdr cmd.Commander) error {
 Lists all registered users. Workflow administrators will be marked with a *.
 Requires admin privileges.
 
-Usage: deis users:list [options]
+Usage: hephy users:list [options]
 
 Options:
   -l --limit=<num>

--- a/parser/users_test.go
+++ b/parser/users_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 )
 
 func safeGetValue(args map[string]interface{}, key string) string {
@@ -36,8 +36,8 @@ func responseLimit(limit string) (int, error) {
 
 // PrintUsage runs if no matching command is found.
 func PrintUsage(cmdr cmd.Commander) {
-	cmdr.PrintErrln("Found no matching command, try 'deis help'")
-	cmdr.PrintErrln("Usage: deis <command> [<args>...]")
+	cmdr.PrintErrln("Found no matching command, try 'hephy help'")
+	cmdr.PrintErrln("Usage: hephy <command> [<args>...]")
 }
 
 func printHelp(argv []string, usage string) bool {

--- a/parser/version.go
+++ b/parser/version.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -10,7 +10,7 @@ func Version(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Displays the client version.
 
-Usage: deis version [options]
+Usage: hephy version [options]
 
 Options:
   -a --all

--- a/parser/version_test.go
+++ b/parser/version_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/whitelist.go
+++ b/parser/whitelist.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
@@ -14,7 +14,7 @@ whitelist:add           adds addresses to the application's whitelist
 whitelist:list          list addresses in the application's whitelist
 whitelist:remove        remove addresses from the application's whitelist
 
-Use 'deis help [command]' to learn more.
+Use 'hephy help [command]' to learn more.
 `
 
 	switch argv[0] {
@@ -43,7 +43,7 @@ func whitelistAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Adds addresses to an application whitelist.
 
-Usage: deis whitelist:add <addresses> [options]
+Usage: hephy whitelist:add <addresses> [options]
 
 Arguments:
   <addresses>
@@ -70,7 +70,7 @@ func whitelistList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists whitelisted addresses for an application.
 
-Usage: deis whitelist:list [options]
+Usage: hephy whitelist:list [options]
 
 Options:
   -a --app=<app>
@@ -92,7 +92,7 @@ func whitelistRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Removes addresses from an application whitelist.
 
-Usage: deis whitelist:remove <addresses> [options]
+Usage: hephy whitelist:remove <addresses> [options]
 
 Arguments:
   <addresses>

--- a/parser/whitelist_test.go
+++ b/parser/whitelist_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/pkg/logging/log_unix.go
+++ b/pkg/logging/log_unix.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 )
 
 const colorStringEscape = "\033[3%dm"

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // TestServer represents a test HTTP server along with a path to a config file

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/version"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 // DefaultResponseLimit is the default number of responses to return on requests that can
@@ -40,7 +40,7 @@ func Load(cf string) (*Settings, error) {
 	if _, err := os.Stat(filename); err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf(`Client configuration file not found at: %s
-Are you logged in? Use 'deis login' or 'deis register' to get started.`, filename)
+Are you logged in? Use 'hephy login' or 'hephy register' to get started.`, filename)
 		}
 
 		return nil, err
@@ -90,7 +90,7 @@ func (s *Settings) Save(cf string) (string, error) {
 		return "", err
 	}
 
-	if err = os.MkdirAll(filepath.Join(FindHome(), "/.deis/"), 0700); err != nil {
+	if err = os.MkdirAll(filepath.Join(FindHome(), "/.hephy/"), 0700); err != nil {
 		return "", err
 	}
 

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/version"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 const sFile string = `{"username":"t","ssl_verify":false,"controller":"http://foo.bar","token":"a"}`


### PR DESCRIPTION
for now I am just using my own quay account, but this is part of e2e POC
'kingdonb' will probably become 'hephy' or 'teamhephy' in a later commit

It would be great if I could get perms to merge stuff like this in so I can keep building out CI!