### PR TITLE
chore(install-v2.sh): hephy google storage deis cli links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 
-|![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Deis Workflow will soon no longer be maintained.<br />Please [read the announcement](https://deis.com/blog/2017/deis-workflow-final-release/) for more detail. |
+|![](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Anchor_pictogram_yellow.svg/156px-Anchor_pictogram_yellow.svg.png) | Hephy Workflow is the open source fork of Deis Workflow.<br />Please [go here](https://www.teamhephy.com/) for more detail. |
 |---:|---|
+| 08/27/2018 | Team Hephy [blog][] comes online |
+| 08/20/2018 | Deis [#community slack][] goes dark |
+| 08/10/2018 | Hephy Workflow [v2.19.4][] fourth patch release |
+| 08/08/2018 | [Deis website][] goes dark, then redirects to Azure Kubernetes Service |
+| 08/01/2018 | Hephy Workflow [v2.19.3][] third patch release |
+| 07/17/2018 | Hephy Workflow [v2.19.2][] second patch release |
+| 07/12/2018 | Hephy Workflow [v2.19.1][] first patch release |
+| 06/29/2018 | Hephy Workflow [v2.19.0][] first release in the open source fork of Deis |
+| 06/16/2018 | Hephy Workflow [v2.19][] series is announced |
+| 03/01/2018 | End of Deis Workflow maintenance: critical patches no longer merged |
+| 12/11/2017 | Team Hephy [slack community][] invites first volunteers |
 | 09/07/2017 | Deis Workflow [v2.18][] final release before entering maintenance mode |
-| 03/01/2018 | End of Workflow maintenance: critical patches no longer merged |
+| 09/06/2017 | Team Hephy [slack community][] comes online |
 
 # Deis Client
 
@@ -157,3 +168,19 @@ To learn more about a command run `deis help <command>`.
 see [LICENSE](https://github.com/teamhephy/workflow-cli/blob/master/LICENSE)
 
 [v2.18]: https://github.com/teamhephy/workflow/releases/tag/v2.18.0
+[k8s-home]: http://kubernetes.io
+[install-k8s]: http://kubernetes.io/gettingstarted/
+[mkdocs]: http://www.mkdocs.org/
+[issues]: https://github.com/teamhephy/workflow/issues
+[prs]: https://github.com/teamhephy/workflow/pulls
+[Deis website]: http://deis.com/
+[blog]: https://blog.teamhephy.info/blog/
+[#community slack]: https://slack.deis.io/
+[slack community]: https://slack.teamhephy.com/
+[v2.18]: https://github.com/teamhephy/workflow/releases/tag/v2.18.0
+[v2.19]: https://web.teamhephy.com
+[v2.19.0]: https://gist.github.com/Cryptophobia/24c204583b18b9fc74c629fb2b62dfa3/revisions
+[v2.19.1]: https://github.com/teamhephy/workflow/releases/tag/v2.19.1
+[v2.19.2]: https://github.com/teamhephy/workflow/releases/tag/v2.19.2
+[v2.19.3]: https://github.com/teamhephy/workflow/releases/tag/v2.19.3
+[v2.19.4]: https://github.com/teamhephy/workflow/releases/tag/v2.19.4

--- a/install-v2.sh
+++ b/install-v2.sh
@@ -3,10 +3,10 @@
 # Invoking this script:
 #
 # To install the latest stable version:
-# curl https://deis.io/deis-cli/install-v2.sh | sh
+# curl https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh | sh
 #
 # To install a specific released version ($VERSION):
-# curl https://deis.io/deis-cli/install-v2.sh | sh -s $VERSION
+# curl https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh | sh -s $VERSION
 #
 # - download deis cli binary
 # - making sure deis cli binary is executable
@@ -24,9 +24,9 @@ check_platform_arch() {
   if ! echo "${supported}" | tr ' ' '\n' | grep -q "${PLATFORM}-${ARCH}"; then
     cat <<EOF
 
-The Deis Workflow CLI (deis) is not currently supported on ${PLATFORM}-${ARCH}.
+The Hephy Workflow CLI (deis) is not currently supported on ${PLATFORM}-${ARCH}.
 
-See https://deis.com/workflow/ for more information.
+See https://github.com/teamhephy/workflow-cli for more information.
 
 EOF
   fi
@@ -34,8 +34,8 @@ EOF
 
 PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
-# https://storage.googleapis.com/workflow-cli-release/v2.0.0/deis-v2.0.0-darwin-386
-DEIS_BIN_URL_BASE="https://storage.googleapis.com/workflow-cli-release"
+# https://storage.googleapis.com/hephy-workflow-cli-release/v2.18.0/deis-v2.18.0-darwin-386
+DEIS_BIN_URL_BASE="https://storage.googleapis.com/hephy-workflow-cli-release""
 
 if [ "${ARCH}" = "x86_64" ]; then
   ARCH="amd64"
@@ -50,15 +50,16 @@ if [ "${VERSION}" != 'stable' ]; then
 fi
 
 echo "Downloading ${DEIS_CLI} From Google Cloud Storage..."
+echo "Downloading binary from here: ${DEIS_BIN_URL_BASE}/${DEIS_CLI_PATH}
 curl -fsSL -o deis "${DEIS_BIN_URL_BASE}/${DEIS_CLI_PATH}"
 
 chmod +x deis
 
 cat <<EOF
 
-The Deis Workflow CLI (deis) is now available in your current directory.
+The Hephy Workflow CLI (deis) is now available in your current directory.
 
-To learn more about Deis Workflow, execute:
+To learn more about Hephy Workflow, execute:
 
     $ ./deis --help
 


### PR DESCRIPTION
This is the fix for the script install-v2.sh for the deis-cli in order to move away from deprecated google storage account of deis.io and to use our own Hephy google storage for the deis-cli.

This will make sure that `dpl` gem works for a long time for Deis and Hephy providers. https://github.com/travis-ci/dpl/pull/850