### PR TITLE
chore(workflow-cli): Moving to teamhephy org - links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing to Deis
 
 This project is part of Deis. You can find the latest contribution
-guidelines [in our documentation](https://deis.com/docs/workflow/contributing/overview/).
+guidelines [in our documentation](https://docs.teamhephy.com/contributing/overview/).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/go-dev:v0.22.0
+FROM hephy/go-dev:v0.22.0
 # This Dockerfile is used to bundle the source and all dependencies into an image for testing.
 
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-jessie main" \
@@ -15,13 +15,13 @@ ENV CGO_ENABLED=0
 ADD https://codecov.io/bash /usr/local/bin/codecov
 RUN chmod +x /usr/local/bin/codecov
 
-COPY glide.yaml /go/src/github.com/deis/workflow-cli/
-COPY glide.lock /go/src/github.com/deis/workflow-cli/
+COPY glide.yaml /go/src/github.com/teamhephy/workflow-cli/
+COPY glide.lock /go/src/github.com/teamhephy/workflow-cli/
 
-WORKDIR /go/src/github.com/deis/workflow-cli
+WORKDIR /go/src/github.com/teamhephy/workflow-cli
 
 RUN glide install --strip-vendor
 
 COPY ./_scripts /usr/local/bin
 
-COPY . /go/src/github.com/deis/workflow-cli
+COPY . /go/src/github.com/teamhephy/workflow-cli

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # the filepath to this repository, relative to $GOPATH/src
-repo_path = github.com/deis/workflow-cli
+repo_path = github.com/teamhephy/workflow-cli
 
 HOST_OS := $(shell uname)
 ifeq ($(HOST_OS),Darwin)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 # Deis Client
 
 [![Build Status](https://ci.deis.io/buildStatus/icon?job=Deis/workflow-cli/master)](https://ci.deis.io/job/Deis/job/workflow-cli/job/master/)
-[![Go Report Card](https://goreportcard.com/badge/github.com/deis/workflow-cli)](https://goreportcard.com/report/github.com/deis/workflow-cli)
+[![Go Report Card](https://goreportcard.com/badge/github.com/teamhephy/workflow-cli)](https://goreportcard.com/report/github.com/teamhephy/workflow-cli)
 [![codebeat badge](https://codebeat.co/badges/05d314a8-ca61-4211-b69e-e7a3033662c8)](https://codebeat.co/projects/github-com-deis-workflow-cli)
 [![codecov](https://codecov.io/gh/deis/workflow-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/deis/workflow-cli)
 

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/apps"
-	"github.com/deis/controller-sdk-go/config"
-	"github.com/deis/controller-sdk-go/domains"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/pkg/logging"
-	"github.com/deis/workflow-cli/pkg/webbrowser"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/apps"
+	"github.com/teamhephy/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/domains"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/pkg/logging"
+	"github.com/teamhephy/workflow-cli/pkg/webbrowser"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // AppCreate creates an app.

--- a/cmd/apps_test.go
+++ b/cmd/apps_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/arschles/assert"
 
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/pkg/testutil"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 type expandURLCases struct {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"syscall"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/auth"
-	"github.com/deis/workflow-cli/settings"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/auth"
+	"github.com/teamhephy/workflow-cli/settings"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestRegister(t *testing.T) {

--- a/cmd/autoscale.go
+++ b/cmd/autoscale.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // AutoscaleList tells the informations about app's autoscale status

--- a/cmd/autoscale_test.go
+++ b/cmd/autoscale_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestAutoscaleList(t *testing.T) {

--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -6,7 +6,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/deis/controller-sdk-go/builds"
+	"github.com/teamhephy/controller-sdk-go/builds"
 )
 
 // BuildsList lists an app's builds.

--- a/cmd/builds_test.go
+++ b/cmd/builds_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestParseProcfile(t *testing.T) {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/certs"
-	dtime "github.com/deis/controller-sdk-go/pkg/time"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/certs"
+	dtime "github.com/teamhephy/controller-sdk-go/pkg/time"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 const dateFormat = "2 Jan 2006"

--- a/cmd/certs_test.go
+++ b/cmd/certs_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestCertsList(t *testing.T) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/deis/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // Commander is interface definition for running commands

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // ConfigList lists an app's config.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestParseConfig(t *testing.T) {

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/deis/controller-sdk-go/domains"
+import "github.com/teamhephy/controller-sdk-go/domains"
 
 // DomainsList lists domains registered with an app.
 func (d *DeisCmd) DomainsList(appID string, results int) error {

--- a/cmd/domains_test.go
+++ b/cmd/domains_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestDomainsList(t *testing.T) {

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/pkg/git"
 )
 
 const remoteCreationMsg = "Git remote %s successfully created for app %s.\n"

--- a/cmd/healthchecks.go
+++ b/cmd/healthchecks.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"sort"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 func (d *DeisCmd) printHealthCheck(healthcheck api.Healthchecks) {

--- a/cmd/healthchecks_test.go
+++ b/cmd/healthchecks_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestPrintHealthCheck(t *testing.T) {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/keys"
-	"github.com/deis/workflow-cli/pkg/ssh"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/keys"
+	"github.com/teamhephy/workflow-cli/pkg/ssh"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // KeysList lists a user's keys.

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 func TestGetKey(t *testing.T) {

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // LabelsList list app's labels

--- a/cmd/labels_test.go
+++ b/cmd/labels_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 	"strings"
 )
 

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // LimitsList lists an app's limits.

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 type parseLimitCase struct {

--- a/cmd/maintenance.go
+++ b/cmd/maintenance.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // MaintenanceInfo tells the informations about app's maintenance status

--- a/cmd/maintenance_test.go
+++ b/cmd/maintenance_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestMaintenanceInfo(t *testing.T) {

--- a/cmd/perms.go
+++ b/cmd/perms.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/perms"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/perms"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // PermsList prints which users have permissions.

--- a/cmd/perms_test.go
+++ b/cmd/perms_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestPermsListUsers(t *testing.T) {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/ps"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/ps"
 )
 
 // PsList lists an app's processes.

--- a/cmd/ps_test.go
+++ b/cmd/ps_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/pkg/time"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/pkg/time"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestParseType(t *testing.T) {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // RegistryList lists an app's registry information.

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 type parseInfoCase struct {

--- a/cmd/releases.go
+++ b/cmd/releases.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/deis/controller-sdk-go/releases"
+	"github.com/teamhephy/controller-sdk-go/releases"
 )
 
 // ReleasesList lists an app's releases.

--- a/cmd/releases_test.go
+++ b/cmd/releases_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestReleasesList(t *testing.T) {

--- a/cmd/routing.go
+++ b/cmd/routing.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/appsettings"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/appsettings"
 )
 
 // RoutingInfo provides information about the status of app routing.

--- a/cmd/routing_test.go
+++ b/cmd/routing_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestRoutingInfo(t *testing.T) {

--- a/cmd/shortcuts.go
+++ b/cmd/shortcuts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/deis/workflow-cli/cli"
+	"github.com/teamhephy/workflow-cli/cli"
 )
 
 // ShortcutsList displays all relevant shortcuts for the CLI.

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/config"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/config"
 )
 
 // TagsList lists an app's tags.

--- a/cmd/tags_test.go
+++ b/cmd/tags_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 type parseTagCase struct {

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/deis/controller-sdk-go/tls"
+import "github.com/teamhephy/controller-sdk-go/tls"
 
 // TLSInfo prints info about the TLS settings for the given app.
 func (d *DeisCmd) TLSInfo(appID string) error {

--- a/cmd/tls_test.go
+++ b/cmd/tls_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestTLSInfo(t *testing.T) {

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/deis/controller-sdk-go/users"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go/users"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // UsersList lists users registered with the controller.

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestUsersList(t *testing.T) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/settings"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 var defaultLimit = -1

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/pkg/git"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/pkg/git"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 func TestLoad(t *testing.T) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/settings"
-	"github.com/deis/workflow-cli/version"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/settings"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 // Version prints the various CLI versions.

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/pkg/testutil"
-	"github.com/deis/workflow-cli/version"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 func TestVersion(t *testing.T) {

--- a/cmd/whitelist.go
+++ b/cmd/whitelist.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"strings"
 
-	"github.com/deis/controller-sdk-go/whitelist"
+	"github.com/teamhephy/controller-sdk-go/whitelist"
 )
 
 // WhitelistList lists the addresses whitelisted for app

--- a/cmd/whitelist_test.go
+++ b/cmd/whitelist_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func TestWhitelistList(t *testing.T) {

--- a/deis.go
+++ b/deis.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/deis/workflow-cli/cli"
-	"github.com/deis/workflow-cli/cmd"
-	"github.com/deis/workflow-cli/parser"
+	"github.com/teamhephy/workflow-cli/cli"
+	"github.com/teamhephy/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/parser"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,9 +1,26 @@
-hash: df0e54f151fe59020aeb6596445430c9185644ffe1650c9c80f020f04bffb60f
-updated: 2017-01-09T11:54:15.635074917-08:00
+hash: 3278f16b1420d2b304fd37505afc7f8d3819c6fd818242e2b9070cc71fcef7e6
+updated: 2018-09-27T16:45:00.103264871-04:00
 imports:
 - name: github.com/arschles/assert
   version: bb58b908265b5931732079df03f2818bf2167ba0
 - name: github.com/deis/controller-sdk-go
+  version: 9520b6c460202f376856d042ac4864ee951cdf3a
+  subpackages:
+  - api
+  - pkg/time
+- name: github.com/docopt/docopt-go
+  version: ee0de3bc6815ee19d4a46c7eb90f829db0e014b1
+- name: github.com/goware/urlx
+  version: 8bb4a2e4339f55b15164907177e96e9faf885504
+- name: github.com/mattn/go-runewidth
+  version: ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb
+- name: github.com/olekukonko/tablewriter
+  version: be2c049b30ccd4d3fd795d6bf7dce74e42eeedaa
+- name: github.com/PuerkitoBio/purell
+  version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/teamhephy/controller-sdk-go
   version: 9520b6c460202f376856d042ac4864ee951cdf3a
   subpackages:
   - api
@@ -22,25 +39,13 @@ imports:
   - tls
   - users
   - whitelist
-- name: github.com/deis/pkg
-  version: 28bd07fbcbec5aaaaeda05d362d8ff81f55f4f6c
+- name: github.com/teamhephy/pkg
+  version: 777f37a30108edaf6a2bd4e423cde34ec12870fd
   subpackages:
   - prettyprint
   - time
-- name: github.com/docopt/docopt-go
-  version: 784ddc588536785e7299f7272f39101f7faccc3f
-- name: github.com/goware/urlx
-  version: 8bb4a2e4339f55b15164907177e96e9faf885504
-- name: github.com/mattn/go-runewidth
-  version: 737072b4e32b7a5018b4a7125da8d12de90e8045
-- name: github.com/olekukonko/tablewriter
-  version: bdcc175572fd7abece6c831e643891b9331bc9e7
-- name: github.com/PuerkitoBio/purell
-  version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: golang.org/x/crypto
-  version: 9a6f0a01987842989747adff311d80750ba25530
+  version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -49,9 +54,10 @@ imports:
   - context
   - idna
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 47a200a05c8b3fd1b698571caecbb68beb2611ec
   subpackages:
@@ -59,5 +65,5 @@ imports:
   - unicode/norm
   - width
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: 670d4cfef0544295bc27a114dbac37980d83185a
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,11 +1,11 @@
-package: github.com/deis/workflow-cli
+package: github.com/teamhephy/workflow-cli
 ignore:
 - appengine
 - appengine/user
 - appengine/datastore
 - appengine/memcache
 import:
-- package: github.com/deis/pkg
+- package: github.com/teamhephy/pkg
   subpackages:
   - time
 - package: github.com/docopt/docopt-go
@@ -15,5 +15,5 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/olekukonko/tablewriter
 - package: github.com/arschles/assert
-- package: github.com/deis/controller-sdk-go
+- package: github.com/teamhephy/controller-sdk-go
   version: 9520b6c460202f376856d042ac4864ee951cdf3a

--- a/parser/apps.go
+++ b/parser/apps.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/apps_test.go
+++ b/parser/apps_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/auth.go
+++ b/parser/auth.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/auth_test.go
+++ b/parser/auth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/autoscale.go
+++ b/parser/autoscale.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/autoscale_test.go
+++ b/parser/autoscale_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/builds.go
+++ b/parser/builds.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/builds_test.go
+++ b/parser/builds_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 func (d FakeDeisCmd) BuildsList(string, int) error {

--- a/parser/certs.go
+++ b/parser/certs.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"time"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/certs_test.go
+++ b/parser/certs_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/config.go
+++ b/parser/config.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/domains.go
+++ b/parser/domains.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/domains_test.go
+++ b/parser/domains_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/git.go
+++ b/parser/git.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/git_test.go
+++ b/parser/git_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/healthchecks.go
+++ b/parser/healthchecks.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 
-	"github.com/deis/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/api"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/healthchecks_test.go
+++ b/parser/healthchecks_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/keys.go
+++ b/parser/keys.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/keys_test.go
+++ b/parser/keys_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/labels.go
+++ b/parser/labels.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/labels_test.go
+++ b/parser/labels_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/limits.go
+++ b/parser/limits.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/limits_test.go
+++ b/parser/limits_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/maintenance.go
+++ b/parser/maintenance.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/maintenance_test.go
+++ b/parser/maintenance_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/perms.go
+++ b/parser/perms.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/perms_test.go
+++ b/parser/perms_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/ps.go
+++ b/parser/ps.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/ps_test.go
+++ b/parser/ps_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/registry.go
+++ b/parser/registry.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/registry_test.go
+++ b/parser/registry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/releases.go
+++ b/parser/releases.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/releases_test.go
+++ b/parser/releases_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/routing.go
+++ b/parser/routing.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/routing_test.go
+++ b/parser/routing_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/shortcuts.go
+++ b/parser/shortcuts.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/shortcuts_test.go
+++ b/parser/shortcuts_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/tags.go
+++ b/parser/tags.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/tags_test.go
+++ b/parser/tags_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/tls.go
+++ b/parser/tls.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/tls_test.go
+++ b/parser/tls_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/users.go
+++ b/parser/users.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/users_test.go
+++ b/parser/users_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 )
 
 func safeGetValue(args map[string]interface{}, key string) string {

--- a/parser/version.go
+++ b/parser/version.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/version_test.go
+++ b/parser/version_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/parser/whitelist.go
+++ b/parser/whitelist.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/cmd"
+	"github.com/teamhephy/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/whitelist_test.go
+++ b/parser/whitelist_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/teamhephy/workflow-cli/pkg/testutil"
 )
 
 // Create fake implementations of each method that return the argument

--- a/pkg/logging/log_unix.go
+++ b/pkg/logging/log_unix.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/deis/pkg/prettyprint"
+	"github.com/teamhephy/pkg/prettyprint"
 )
 
 const colorStringEscape = "\033[3%dm"

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/settings"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/settings"
 )
 
 // TestServer represents a test HTTP server along with a path to a config file

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/workflow-cli/version"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 // DefaultResponseLimit is the default number of responses to return on requests that can

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-	"github.com/deis/workflow-cli/version"
+	"github.com/teamhephy/workflow-cli/version"
 )
 
 const sFile string = `{"username":"t","ssl_verify":false,"controller":"http://foo.bar","token":"a"}`


### PR DESCRIPTION
Doing this to move workflow-cli to teamhephy org and build there. Also to resolve https://github.com/teamhephy/workflow-cli/pull/32