### PR TITLE
Add travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
-sudo: required
-
-services:
-  - docker
-
-script: make test
+go:
+    - "1.10"
+jobs:
+    include:
+        -   stage: Test and build
+            script:
+                REVISION=${TRAVIS_COMMIT::7} make test && docker run -e BUILD_ARCH=amd64 -e REVISION=${TRAVIS_COMMIT::7} -e GIT_TAG=$(git describe --abbrev=0 --tags) -e DIST_DIR=/upload -v $(pwd)/_dist/:/upload --rm quay.io/deisci/workflow-cli-dev:${TRAVIS_COMMIT::7} make build-all


### PR DESCRIPTION
Added travis CI with a simpler travis.yml - and using travis-ci.com (https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps). We can change the README with your travis ci account once the PR is merged.