### PR TITLE
Support darwin/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ REGISTRY ?=
 IMAGE_PREFIX ?= hephy
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/workflow-cli-dev:${REVISION}
 
-BUILD_OS ?=linux darwin windows
-BUILD_ARCH ?=amd64 386 arm64
+BUILD_LIST ?=-os=darwin -os=linux -os=windows -arch=amd64 -arch=arm64 -osarch=linux/386 -osarch=windows/386
 
 DIST_DIR ?= _dist
 
@@ -39,22 +38,22 @@ build: build-test-image
 # This is supposed to be run within a docker container
 build-latest:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}-${REVISION}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/deis-latest-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} ${BUILD_LIST} -output="${DIST_DIR}/deis-latest-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
 build-revision:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}-${REVISION}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${REVISION}/deis-${REVISION}-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} ${BUILD_LIST} -output="${DIST_DIR}/${REVISION}/deis-${REVISION}-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
 build-stable:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/deis-stable-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} ${BUILD_LIST} -output="${DIST_DIR}/deis-stable-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
 build-tag:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}')
-	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${GIT_TAG}/deis-${GIT_TAG}-{{.OS}}-{{.Arch}}" .
+	gox -verbose ${GO_LDFLAGS} ${BUILD_LIST} -output="${DIST_DIR}/${GIT_TAG}/deis-${GIT_TAG}-{{.OS}}-{{.Arch}}" .
 
 build-all: build-latest build-revision
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ IMAGE_PREFIX ?= hephy
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/workflow-cli-dev:${REVISION}
 
 BUILD_OS ?=linux darwin windows
-BUILD_ARCH ?=amd64 386
+BUILD_ARCH ?=amd64 386 arm64
 
 DIST_DIR ?= _dist
 


### PR DESCRIPTION
I ran into the same issue described in this PR:

https://github.com/Automattic/go-search-replace/pull/28/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L8

Looks like this is something that is broken in the base branch. The way I mitigated it is a bit ugly but it works?

Ran a test with a recent go compiler (1.17.2) and the latest version of `gox` at the ready:

```
:~/projects/hephy/workflow-cli (master u=)$ go install github.com/mitchellh/gox@latest

:~/projects/hephy/workflow-cli (master u=)$ make build-latest
gox -verbose -ldflags '-X github.com/teamhephy/workflow-cli/version.Version=v2.22.0-f015abf8' -os="linux darwin windows" -arch="amd64 386" -output="_dist/deis-latest-{{.OS}}-{{.Arch}}" .
Number of parallel builds: 7

-->     windows/386: github.com/teamhephy/workflow-cli
-->    darwin/amd64: github.com/teamhephy/workflow-cli
-->     linux/amd64: github.com/teamhephy/workflow-cli
-->       linux/386: github.com/teamhephy/workflow-cli
-->      darwin/386: github.com/teamhephy/workflow-cli
-->   windows/amd64: github.com/teamhephy/workflow-cli

1 errors occurred:
--> darwin/386 error: exit status 2
Stderr: cmd/go: unsupported GOOS/GOARCH pair darwin/386

make: *** [build-latest] Error 1

:~/projects/hephy/workflow-cli (master u=)$ git co support-darwin-arm64
Switched to branch 'support-darwin-arm64'

:~/projects/hephy/workflow-cli (support-darwin-arm64)$ make build-latest
gox -verbose -ldflags '-X github.com/teamhephy/workflow-cli/version.Version=v2.22.0-ea7f801e' -os=darwin -os=linux -os=windows -arch=amd64 -arch=arm64 -osarch=linux/386 -osarch=windows/386 -output="_dist/deis-latest-{{.OS}}-{{.Arch}}" .
Number of parallel builds: 7

-->   windows/amd64: github.com/teamhephy/workflow-cli
-->    darwin/amd64: github.com/teamhephy/workflow-cli
-->     windows/386: github.com/teamhephy/workflow-cli
-->       linux/386: github.com/teamhephy/workflow-cli
-->     linux/amd64: github.com/teamhephy/workflow-cli
-->     linux/arm64: github.com/teamhephy/workflow-cli
-->    darwin/arm64: github.com/teamhephy/workflow-cli

```